### PR TITLE
Add blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/post.php?post=5&action=edit",
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "piano-block"
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php\ninclude 'wordpress/wp-load.php';\nwp_insert_post(array(\n'import_id' => 5,\n'post_title' => 'Piano Block',\n'post_content' => '<!-- wp:piano-block/piano /-->',\n'post_status' => 'publish',\n'post_author' => 1\n));"
+		}
+	]
+}


### PR DESCRIPTION
Query API経由では動作する事は確認済

https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/t-hamano/piano-block/add-blueprints/.wordpress-org/blueprints/blueprint.json