### PR TITLE
Refactor TypeScript types and simplify getSamplerFileNames

### DIFF
--- a/src/components/controls/index.tsx
+++ b/src/components/controls/index.tsx
@@ -44,8 +44,8 @@ const Controls = ( { settings, piano, onChange }: Props ) => {
 		keyLayout,
 		keyIndicator,
 	} = settings;
-	const [ isHelpOpen, setIsHelpOpen ] = useState< boolean >( false );
-	const [ isSynthesizerSettingOpen, setIsSynthesizerSettingOpen ] = useState< boolean >( false );
+	const [ isHelpOpen, setIsHelpOpen ] = useState( false );
+	const [ isSynthesizerSettingOpen, setIsSynthesizerSettingOpen ] = useState( false );
 
 	const onVolumeChange = ( newVolume: number | undefined ) => {
 		const instrumentSetting = INSTRUMENTS.find( ( { value } ) => value === instrument );

--- a/src/components/piano/index.tsx
+++ b/src/components/piano/index.tsx
@@ -23,7 +23,7 @@ import type { BlockAttributes, Key } from '../../constants';
 
 type Props = {
 	settings: BlockAttributes;
-	onChange: ( {}: Partial< BlockAttributes > ) => void;
+	onChange: ( newSettings: Partial< BlockAttributes > ) => void;
 };
 
 const Piano = ( { settings, onChange }: Props ) => {
@@ -38,9 +38,9 @@ const Piano = ( { settings, onChange }: Props ) => {
 		keyIndicator,
 	} = settings;
 	const [ piano, setPiano ] = useState< Tone.Sampler | Tone.PolySynth >();
-	const [ isReady, setIsReady ] = useState< boolean >( false );
+	const [ isReady, setIsReady ] = useState( false );
 	const [ activeKeys, setActiveKeys ] = useState< Key[] >( [] );
-	const [ instrumentOctaveOffset, setInstrumentOctaveOffset ] = useState< number >( 0 );
+	const [ instrumentOctaveOffset, setInstrumentOctaveOffset ] = useState( 0 );
 
 	const ref = useRef< HTMLDivElement >( null );
 

--- a/src/components/synthesizer-setting/index.tsx
+++ b/src/components/synthesizer-setting/index.tsx
@@ -24,7 +24,7 @@ import type { BlockAttributes, EmvelopeControl } from '../../constants';
 
 type Props = {
 	synthesizerSetting: BlockAttributes[ 'synthesizerSetting' ];
-	onChange: ( {}: BlockAttributes[ 'synthesizerSetting' ] ) => void;
+	onChange: ( newSynthesizerSetting: BlockAttributes[ 'synthesizerSetting' ] ) => void;
 };
 
 const SynthesizerSetting = ( { synthesizerSetting, onChange }: Props ) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,12 +15,9 @@ export function getSamplerFileNames( notes: string[] ) {
 		return {};
 	}
 
-	return notes.reduce( ( accumulator: { [ key: string ]: string }, note: string ) => {
-		return {
-			...accumulator,
-			[ note.replace( 's', '#' ) ]: `${ note }.mp3`,
-		};
-	}, {} );
+	return Object.fromEntries(
+		notes.map( ( note ) => [ note.replace( 's', '#' ), `${ note }.mp3` ] )
+	);
 }
 
 /**

--- a/src/view.tsx
+++ b/src/view.tsx
@@ -18,7 +18,7 @@ import {
 import type { BlockAttributes } from './constants';
 
 function View( props: BlockAttributes ) {
-	const [ settings, setSettings ] = useState< BlockAttributes >( props );
+	const [ settings, setSettings ] = useState( props );
 
 	const onChange = ( newSettings: Partial< BlockAttributes > ) => {
 		setSettings( {


### PR DESCRIPTION
Tidy up types and a redundant reduce in the source:

- Drop explicit useState type arguments that are inferable from their literal initial values (boolean/number, and the View props seed).
- Name the onChange callback parameters instead of using an empty destructuring pattern ({}), which obscured intent in the Piano and SynthesizerSetting props.
- Rebuild getSamplerFileNames with Object.fromEntries over a map, replacing the spread-in-reduce (O(n^2)) and its now-unneeded accumulator/note annotations.