### PR TITLE
Fix stored XSS in synthesizer setting attribute output

### DIFF
--- a/piano-block.php
+++ b/piano-block.php
@@ -57,25 +57,15 @@ function piano_block_render_callback( $attributes ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'data-volume'            => $volume,
-			'data-use-sustain-pedal' => $use_sustain_pedal ? 1 : 0,
-			'data-octave-offset'     => $octave_offset,
-			'data-instrument'        => $instrument,
-			'data-key-layout'        => $key_layout,
-			'data-key-indicator'     => $key_indicator,
+			'data-volume'              => $volume,
+			'data-use-sustain-pedal'   => $use_sustain_pedal ? 1 : 0,
+			'data-octave-offset'       => $octave_offset,
+			'data-instrument'          => $instrument,
+			'data-key-layout'          => $key_layout,
+			'data-key-indicator'       => $key_indicator,
+			'data-synthesizer-setting' => wp_json_encode( $synthesizer_setting ),
 		)
 	);
-
-	if ( ! empty( $synthesizer_setting ) ) {
-		$escaped_synthesizer_setting = array_map(
-			function ( $attribute ) {
-				return is_array( $attribute ) ? array_map( 'esc_attr', $attribute ) : esc_attr( $attribute );
-			},
-			$synthesizer_setting
-		);
-
-		$wrapper_attributes .= " data-synthesizer-setting='" . wp_json_encode( $escaped_synthesizer_setting ) . "'";
-	}
 
 	wp_set_script_translations( 'piano-block-piano-view-script', 'piano-block' );
 


### PR DESCRIPTION
The synthesizer setting was concatenated onto the block wrapper attributes manually, escaping only values via esc_attr while leaving object keys unescaped. Since wp_json_encode does not escape quotes or angle brackets, an attacker able to edit the block attributes could inject a crafted key to break out of the single-quoted attribute and execute arbitrary HTML/JS on the front end.

Delegate escaping to get_block_wrapper_attributes() by passing data-synthesizer-setting through its array, so the entire JSON string is escaped with esc_attr by WordPress.