### PR TITLE
Declare directly imported @wordpress packages explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,12 @@
 			"devDependencies": {
 				"@types/wordpress__block-editor": "15.0.6",
 				"@wordpress/base-styles": "10.0.1",
+				"@wordpress/block-editor": "15.21.1",
+				"@wordpress/blocks": "15.21.1",
+				"@wordpress/components": "35.0.1",
+				"@wordpress/compose": "8.1.1",
 				"@wordpress/dom-ready": "4.48.1",
+				"@wordpress/element": "8.0.1",
 				"@wordpress/env": "^11.8.1",
 				"@wordpress/eslint-plugin": "25.4.1",
 				"@wordpress/icons": "^14.0.1",
@@ -2108,6 +2113,82 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@base-ui/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.1",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.6"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -6308,6 +6389,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@preact/signals": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+			"integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
+		"node_modules/@preact/signals-core": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.3.tgz",
+			"integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/@prisma/instrumentation": {
 			"version": "6.11.1",
 			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -6355,6 +6464,431 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+			"integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+			"integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
+			"integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-dismissable-layer": "1.1.13",
+				"@radix-ui/react-focus-guards": "1.1.4",
+				"@radix-ui/react-focus-scope": "1.1.10",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-portal": "1.1.12",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-slot": "1.3.0",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.7.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+			"integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-escape-keydown": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+			"integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+			"integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+			"integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+			"integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+			"integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+			"integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.3.0"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+			"integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+			"integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+			"integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-escape-keydown": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+			"integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-callback-ref": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@react-spring/animated": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+			"integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/core": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+			"integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.5",
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-spring/donate"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/rafz": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+			"integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/shared": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+			"integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/rafz": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-spring/types": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+			"integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@react-spring/web": {
+			"version": "9.7.5",
+			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+			"integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@react-spring/animated": "~9.7.5",
+				"@react-spring/core": "~9.7.5",
+				"@react-spring/shared": "~9.7.5",
+				"@react-spring/types": "~9.7.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@rtsao/scc": {
@@ -7589,65 +8123,171 @@
 				"react-autosize-textarea": "^7.1.0"
 			}
 		},
-		"node_modules/@types/wordpress__block-editor/node_modules/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/base-styles": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
+			"integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/components": {
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
+				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/css": "^11.7.1",
+				"@emotion/react": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/styled": "^11.6.0",
+				"@emotion/utils": "^1.0.0",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.3.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
 			},
 			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@types/wordpress__block-editor/node_modules/react-autosize-textarea": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"autosize": "^4.0.2",
-				"line-height": "^0.3.1",
-				"prop-types": "^15.5.6"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@types/wordpress__block-editor/node_modules/react-dom": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^16.14.0"
+				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@types/wordpress__block-editor/node_modules/scheduler": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/@wordpress/icons": {
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.8.0.tgz",
+			"integrity": "sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/primitives": "^4.41.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/date-fns": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@types/ws": {
@@ -8616,6 +9256,76 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/block-editor": {
+			"version": "15.21.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.21.1.tgz",
+			"integrity": "sha512-LCHp/NoYsR7MV0e7vPNBAgtjHqK3ST4VtduxF5nOgxl0K0zuyvDvanb14EQtY4KmR2Gjndgo72/aZ/kfdQbddg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@react-spring/web": "^9.4.5",
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/base-styles": "^10.0.1",
+				"@wordpress/blob": "^4.48.1",
+				"@wordpress/block-serialization-default-parser": "^5.48.1",
+				"@wordpress/blocks": "^15.21.1",
+				"@wordpress/commands": "^1.48.1",
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/dataviews": "^16.0.1",
+				"@wordpress/date": "^5.48.1",
+				"@wordpress/deprecated": "^4.48.1",
+				"@wordpress/dom": "^4.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/escape-html": "^3.48.1",
+				"@wordpress/global-styles-engine": "^1.15.1",
+				"@wordpress/hooks": "^4.48.1",
+				"@wordpress/html-entities": "^4.48.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/image-cropper": "^1.12.1",
+				"@wordpress/interactivity": "^6.48.1",
+				"@wordpress/is-shallow-equal": "^5.48.1",
+				"@wordpress/keyboard-shortcuts": "^5.48.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/notices": "^5.48.1",
+				"@wordpress/preferences": "^4.48.1",
+				"@wordpress/priority-queue": "^3.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/rich-text": "^7.48.1",
+				"@wordpress/style-engine": "^2.48.1",
+				"@wordpress/token-list": "^3.48.1",
+				"@wordpress/ui": "^0.15.1",
+				"@wordpress/upload-media": "^0.33.1",
+				"@wordpress/url": "^4.48.1",
+				"@wordpress/warning": "^3.48.1",
+				"@wordpress/wordcount": "^4.48.1",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"deepmerge": "^4.3.1",
+				"diff": "^8.0.3",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^2.1.0",
+				"parsel-js": "^1.1.2",
+				"postcss": "^8.4.38",
+				"postcss-prefix-selector": "^1.16.0",
+				"postcss-urlrebase": "^1.4.0",
+				"react-autosize-textarea": "^7.1.0",
+				"react-easy-crop": "^5.4.2",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
 			"version": "5.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.48.1.tgz",
@@ -8670,27 +9380,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/browserslist-config": {
 			"version": "6.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.48.1.tgz",
@@ -8702,60 +9391,25 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/components": {
-			"version": "30.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
-			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
+		"node_modules/@wordpress/commands": {
+			"version": "1.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.48.1.tgz",
+			"integrity": "sha512-yFmQ2yB4tOWPqhO+tE8uYyFqcGwxtOJ9uc1yHYfH40oMls3p+TswktsdbBM2gEmoYxfD+d3Nhp/mXGS38pdTdw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.36.0",
-				"@wordpress/base-styles": "^6.12.0",
-				"@wordpress/compose": "^7.36.0",
-				"@wordpress/date": "^5.36.0",
-				"@wordpress/deprecated": "^4.36.0",
-				"@wordpress/dom": "^4.36.0",
-				"@wordpress/element": "^6.36.0",
-				"@wordpress/escape-html": "^3.36.0",
-				"@wordpress/hooks": "^4.36.0",
-				"@wordpress/html-entities": "^4.36.0",
-				"@wordpress/i18n": "^6.9.0",
-				"@wordpress/icons": "^11.3.0",
-				"@wordpress/is-shallow-equal": "^5.36.0",
-				"@wordpress/keycodes": "^4.36.0",
-				"@wordpress/primitives": "^4.36.0",
-				"@wordpress/private-apis": "^1.36.0",
-				"@wordpress/rich-text": "^7.36.0",
-				"@wordpress/warning": "^3.36.0",
-				"change-case": "^4.1.2",
+				"@wordpress/base-styles": "^10.0.1",
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/keyboard-shortcuts": "^5.48.1",
+				"@wordpress/preferences": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/warning": "^3.48.1",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"cmdk": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8766,66 +9420,91 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/components/node_modules/@wordpress/base-styles": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
-			"integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/components/node_modules/@wordpress/icons": {
-			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.8.0.tgz",
-			"integrity": "sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==",
+		"node_modules/@wordpress/components": {
+			"version": "35.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.1.tgz",
+			"integrity": "sha512-EiTeufX2spZ09kjI8Aa4c7dG6A3WyRSGyHTcCsVnIoE/ykOnAjtGSxnVRAT1KefrJ9RGI8JaTld48wjrB/CS5A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.41.0",
-				"@wordpress/primitives": "^4.41.0",
-				"change-case": "4.1.2"
+				"@ariakit/react": "^0.4.21",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/base-styles": "^10.0.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/date": "^5.48.1",
+				"@wordpress/deprecated": "^4.48.1",
+				"@wordpress/dom": "^4.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/escape-html": "^3.48.1",
+				"@wordpress/hooks": "^4.48.1",
+				"@wordpress/html-entities": "^4.48.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/is-shallow-equal": "^5.48.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/primitives": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/rich-text": "^7.48.1",
+				"@wordpress/style-runtime": "^0.4.1",
+				"@wordpress/ui": "^0.15.1",
+				"@wordpress/warning": "^3.48.1",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "^1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/components/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
-			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.1.tgz",
+			"integrity": "sha512-AEC9yOS5CuTk34F+oiWebhQrxgICnb/v/KScQBUVm6zbs1AMFtu5ku+Zk0A3YTD0tO/hNzXLbvsXhJdh1bGkRA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.46.0",
-				"@wordpress/dom": "^4.46.0",
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/is-shallow-equal": "^5.46.0",
-				"@wordpress/keycodes": "^4.46.0",
-				"@wordpress/priority-queue": "^3.46.0",
-				"@wordpress/undo-manager": "^1.46.0",
+				"@types/react": "^18.3.27",
+				"@wordpress/deprecated": "^4.48.1",
+				"@wordpress/dom": "^4.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/is-shallow-equal": "^5.48.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/priority-queue": "^3.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/undo-manager": "^1.48.1",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -8869,54 +9548,43 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/data/node_modules/@wordpress/compose": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.1.tgz",
-			"integrity": "sha512-AEC9yOS5CuTk34F+oiWebhQrxgICnb/v/KScQBUVm6zbs1AMFtu5ku+Zk0A3YTD0tO/hNzXLbvsXhJdh1bGkRA==",
+		"node_modules/@wordpress/dataviews": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-16.0.1.tgz",
+			"integrity": "sha512-OyDOPvtCIL0AV4wTGSrFHhBVEYwkBJvmfleSjXzGWc09u3BPIiefazoGN4GvtJPJbvieSyelXuVyN+JARIRUug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
+				"@ariakit/react": "^0.4.21",
 				"@types/react": "^18.3.27",
+				"@wordpress/base-styles": "^10.0.1",
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/date": "^5.48.1",
 				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/dom": "^4.48.1",
 				"@wordpress/element": "^8.0.1",
-				"@wordpress/is-shallow-equal": "^5.48.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
 				"@wordpress/keycodes": "^4.48.1",
-				"@wordpress/priority-queue": "^3.48.1",
+				"@wordpress/primitives": "^4.48.1",
 				"@wordpress/private-apis": "^1.48.1",
-				"@wordpress/undo-manager": "^1.48.1",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
+				"@wordpress/ui": "^0.15.1",
+				"@wordpress/warning": "^3.48.1",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/date": {
@@ -9014,19 +9682,20 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
+			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/deprecated": "^4.48.1",
+				"@wordpress/escape-html": "^3.48.1",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9205,21 +9874,39 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/icons/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
+		"node_modules/@wordpress/image-cropper": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.12.1.tgz",
+			"integrity": "sha512-r7t5fzUGzeCt2Pkkp6lgh/a2UKsgW+okeR7Ldw29snE96JZcjYJHyJfRfqOGFZVxrCcoDe2XaEy+Q6PdL+aJhw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"clsx": "^2.1.1",
+				"dequal": "^2.0.3",
+				"react-easy-crop": "^5.4.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/interactivity": {
+			"version": "6.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.48.1.tgz",
+			"integrity": "sha512-Qc+VoBt2XNoOuVMZwjQtZJ8iQfh7mJsSjPlxzSMyYRHGPa+WqfWO50LY/vyXYPs5s5FoMsb3S64ty/p//1DI2w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@preact/signals": "^1.3.0",
+				"preact": "^10.29.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9274,6 +9961,26 @@
 				"jest": ">=29"
 			}
 		},
+		"node_modules/@wordpress/keyboard-shortcuts": {
+			"version": "5.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.48.1.tgz",
+			"integrity": "sha512-HYm/Q52G5UvF4rOleWWJaRvsRjWBOyqhcCdlXXtVAWn7qEq5V2Lm5RSdI4L66EVFqRAHAPsz9ouwwiU98N5NFQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/keycodes": "^4.48.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/keycodes": {
 			"version": "4.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.1.tgz",
@@ -9287,6 +9994,27 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/notices": {
+			"version": "5.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.48.1.tgz",
+			"integrity": "sha512-igkUhvyvp+C61HcE7OBiCPkPYMae8k0BQBZblepXghkX82zlqVe5NiueepWTwY7pFDDEsZlxl9sYF2DWf6HF3w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/data": "^10.48.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -9323,6 +10051,35 @@
 				"postcss": "^8.0.0"
 			}
 		},
+		"node_modules/@wordpress/preferences": {
+			"version": "4.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.48.1.tgz",
+			"integrity": "sha512-ETRFHFXRJ80UYXwjy5FQlAHlVZQjC3PUqvrW6KT8aJT/nsy8+uMLV0FUE1e37QqeAwdwMDj9jC/MNz0m3eRmOw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/base-styles": "^10.0.1",
+				"@wordpress/components": "^35.0.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/deprecated": "^4.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/prettier-config": {
 			"version": "4.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.48.1.tgz",
@@ -9354,27 +10111,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
@@ -9448,56 +10184,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.1.tgz",
-			"integrity": "sha512-AEC9yOS5CuTk34F+oiWebhQrxgICnb/v/KScQBUVm6zbs1AMFtu5ku+Zk0A3YTD0tO/hNzXLbvsXhJdh1bGkRA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/mousetrap": "^1.6.8",
-				"@types/react": "^18.3.27",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/dom": "^4.48.1",
-				"@wordpress/element": "^8.0.1",
-				"@wordpress/is-shallow-equal": "^5.48.1",
-				"@wordpress/keycodes": "^4.48.1",
-				"@wordpress/priority-queue": "^3.48.1",
-				"@wordpress/private-apis": "^1.48.1",
-				"@wordpress/undo-manager": "^1.48.1",
-				"change-case": "^4.1.2",
-				"mousetrap": "^1.6.5",
-				"use-memo-one": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -9959,25 +10645,46 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/theme/node_modules/@wordpress/element": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.1.tgz",
-			"integrity": "sha512-otYhxfm6ZKkcLCl/tI1rB70z6MVDvTL+RiPOWXi4qm0niJf4isSXCcB91ffj1gzJXKbEpszHfysIoU9L2gCSGQ==",
+		"node_modules/@wordpress/token-list": {
+			"version": "3.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.48.1.tgz",
+			"integrity": "sha512-hFAqE8xmTpq/4IVs3AHXxVA2FTrQ2BcOQHsdXJ9kELfcazTZWZsPU2hampfIGYZzyzLnTX06dUubuuy2++LUSQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@types/react": "^18.3.27",
-				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.1",
-				"@wordpress/escape-html": "^3.48.1",
-				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.1.tgz",
+			"integrity": "sha512-zFErzf84zc7dGXrCa9fPKUpMhYx86B8n5GeshC7Ut/nfE7yp09g/Bono5S7KhY1OJx7Z1Jur9t+4vnv5cocBbA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.5.0",
+				"@types/react": "^18.3.27",
+				"@wordpress/a11y": "^4.48.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/icons": "^14.0.1",
+				"@wordpress/keycodes": "^4.48.1",
+				"@wordpress/primitives": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/style-runtime": "^0.4.1",
+				"@wordpress/theme": "^0.15.1",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -9994,12 +10701,94 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/upload-media": {
+			"version": "0.33.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.33.1.tgz",
+			"integrity": "sha512-FjHJGZh7tjUyMbHXiPPHT8oRpM24ENwCOYG7OEoWRGP3NSU5v9Ff4TCksI25Ws420TkrNCFnHlU+xmALQAu30w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@wordpress/blob": "^4.48.1",
+				"@wordpress/compose": "^8.1.1",
+				"@wordpress/data": "^10.48.1",
+				"@wordpress/element": "^8.0.1",
+				"@wordpress/i18n": "^6.21.1",
+				"@wordpress/preferences": "^4.48.1",
+				"@wordpress/private-apis": "^1.48.1",
+				"@wordpress/url": "^4.48.1",
+				"@wordpress/vips": "^2.1.1",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/url": {
+			"version": "4.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.48.1.tgz",
+			"integrity": "sha512-EiTMmEwotXY4Cu6casJ10HEe0ocsdVujkm1iZyA0vvu2qtR5IIQqlSVGxDx96cJBP6cB2b8x2ebGLWfnwow4/Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/vips": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.1.1.tgz",
+			"integrity": "sha512-3NvM0Bk4xrNhYI8Xgn9+dphE3FbJANhe9aNoU1J/Wqmqt3EpUJY5KoykFkfpHJWbdiLohSMkKIyVylGMdHpP7g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/worker-threads": "^1.8.1",
+				"wasm-vips": "^0.0.17"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/warning": {
 			"version": "3.48.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.1.tgz",
 			"integrity": "sha512-5YyMCOHycuHG+AjsVEUafpTqV4b4qjVv/tel5m1L8k8g8dUW5T/XKguFo1nhCqQc4HqoGBrJtKjaf6dMmg8uWg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/wordcount": {
+			"version": "4.48.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.48.1.tgz",
+			"integrity": "sha512-/IdYqxbvAFgAf3O72lUj5ybeWMglG2dYwL8wz17koSHqH5XKlbIQrNGvz4XIvQueiewd4MvLOqIFt2TVHHU6/A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/worker-threads": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.8.1.tgz",
+			"integrity": "sha512-xrVypgVxciFPyc704/0fdQ6bf5BZrf2EXtTPQ4BSU0ylnvfSvgvTCYWdVzlI4VySq+FNfHgLHTCxKiKT23CrSQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"comctx": "^1.4.3"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10504,6 +11293,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/aria-query": {
@@ -12118,6 +12920,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/cmdk": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+			"integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "^1.1.1",
+				"@radix-ui/react-dialog": "^1.1.6",
+				"@radix-ui/react-id": "^1.1.0",
+				"@radix-ui/react-primitive": "^2.0.2"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^18 || ^19 || ^19.0.0-rc"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12193,6 +13012,13 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/comctx": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
+			"integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "12.1.0",
@@ -12897,9 +13723,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -13178,6 +14004,16 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -13217,12 +14053,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1507524",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
 			"integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -15606,6 +16459,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -20392,6 +21255,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/normalize-wheel": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+			"integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -21321,6 +22191,23 @@
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
+		},
+		"node_modules/parsel-js": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.2.tgz",
+			"integrity": "sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/LeaVerou"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/leaverou"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
@@ -22258,6 +23145,16 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-prefix-selector": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
+			"integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"postcss": ">4 <9"
+			}
+		},
 		"node_modules/postcss-reduce-initial": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
@@ -22399,6 +23296,19 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-urlrebase": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+			"integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.0"
+			}
+		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -22447,6 +23357,17 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/preact": {
+			"version": "10.29.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+			"integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -22834,6 +23755,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
 		"node_modules/react-colorful": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
@@ -22868,17 +23805,6 @@
 				"react": ">=16.8.0"
 			}
 		},
-		"node_modules/react-day-picker/node_modules/date-fns": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
-			}
-		},
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -22891,6 +23817,21 @@
 			},
 			"peerDependencies": {
 				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-easy-crop": {
+			"version": "5.5.7",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+			"integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"normalize-wheel": "^1.0.1",
+				"tslib": "^2.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.4.0",
+				"react-dom": ">=16.4.0"
 			}
 		},
 		"node_modules/react-is": {
@@ -22924,6 +23865,78 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.2",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/read-cache": {
@@ -23274,6 +24287,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/reselect": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -25985,6 +27005,13 @@
 				"url": "https://opencollective.com/synckit"
 			}
 		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/table": {
 			"version": "6.9.0",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -27137,6 +28164,28 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/use-memo-one": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
@@ -27145,6 +28194,29 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/use-sync-external-store": {
@@ -27294,6 +28366,16 @@
 			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/wasm-vips": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.17.tgz",
+			"integrity": "sha512-nhkqUNJDUymImoXGrVfImC4wzIFTb9KfBpAngb7dcEQNPP1gVTx4+WL3VVVDSXQpMsyeacsQDOx0+DM33Rpurg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.4.0"
+			}
 		},
 		"node_modules/watchpack": {
 			"version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
 	"devDependencies": {
 		"@types/wordpress__block-editor": "15.0.6",
 		"@wordpress/base-styles": "10.0.1",
+		"@wordpress/block-editor": "15.21.1",
+		"@wordpress/blocks": "15.21.1",
+		"@wordpress/components": "35.0.1",
+		"@wordpress/compose": "8.1.1",
 		"@wordpress/dom-ready": "4.48.1",
+		"@wordpress/element": "8.0.1",
 		"@wordpress/env": "^11.8.1",
 		"@wordpress/eslint-plugin": "25.4.1",
 		"@wordpress/icons": "^14.0.1",


### PR DESCRIPTION
These packages were imported in src/ but resolved implicitly via hoisting (phantom dependencies), risking version mismatches in type resolution. Declare them in devDependencies to pin versions.